### PR TITLE
Fix and Improve Looting Logic

### DIFF
--- a/scripts/looting.sqf
+++ b/scripts/looting.sqf
@@ -1,8 +1,13 @@
-player addEventHandler ["InventoryOpened",{
-        _this spawn {
-            waitUntil {
-                not isNull findDisplay 602
-            };
-            if (_this select 1 isKindOf "Man") then {closeDialog 602 && systemChat "You are not allowed to loot dead soldiers";};
-        }
+player addEventHandler ["InventoryOpened",
+{
+  _container = _this select 1;
+  if ((_container isKindOf "Man") && {!((side _container) isEqualTo playerSide)}) then
+  {
+    systemChat "You are not allowed to loot dead soldiers.";
+    true
+  }
+  else
+  {
+    false
+  };
 }];


### PR DESCRIPTION
Instead of trying to wait for a display to open, the EH simply overrides the inventory menu if you want to prevent looting.

Also added a check to see if the body's "side" is the same as the player's side. Not sure if it will actually work, because player bodies return to side "civ" when they die. Might need to tweak that later, but it gets the job done for now.

NOTE: This will allow you to open inventory if you only see a weapon on the ground, so people will still be able to take whatever weapons/attachments they want as long as they can gear up on it separately from the body.